### PR TITLE
hardening xmin as implicit bookmark field in full table replication

### DIFF
--- a/tap_postgres/sync_strategies/full_table.py
+++ b/tap_postgres/sync_strategies/full_table.py
@@ -149,12 +149,19 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
                 xmin = singer.get_bookmark(state, stream.tap_stream_id, 'xmin')
                 if xmin:
-                    select_sql = 'SELECT {}, xmin::text::bigint FROM {} where xmin::text::bigint > {} order by xmin::text::bigint'.format(','.join(escaped_columns),
-                                                                                                                                          post_db.fully_qualified_table_name(schema_name, stream.table),
-                                                                                                                                          xmin)
+                    LOGGER.info("Resuming Full Table replication %s from xmin %s", nascent_stream_version, xmin)
+                    select_sql = """SELECT {}, xmin::text::bigint
+                                      FROM {} where age(xmin::xid) < age('{}'::xid)
+                                     ORDER BY xmin::text ASC""".format(','.join(escaped_columns),
+                                                                       post_db.fully_qualified_table_name(schema_name, stream.table),
+                                                                       xmin)
                 else:
-                    select_sql = 'SELECT {}, xmin::text::bigint FROM {} order by xmin::text::bigint'.format(','.join(escaped_columns),
-                                                                                                            post_db.fully_qualified_table_name(schema_name, stream.table))
+                    LOGGER.info("Beginning new Full Table replication %s", nascent_stream_version)
+                    select_sql = """SELECT {}, xmin::text::bigint
+                                      FROM {}
+                                     ORDER BY xmin::text ASC""".format(','.join(escaped_columns),
+                                                                       post_db.fully_qualified_table_name(schema_name, stream.table))
+
 
                 LOGGER.info("select %s", select_sql)
                 cur.execute(select_sql)

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -106,7 +106,7 @@ def consume_message(stream, state, msg, time_extracted, md_map):
                                       stream.tap_stream_id,
                                       'lsn',
                                       lsn)
-        LOGGER.info("Flushing log up to LSN  %s", msg.data_start)
+        #LOGGER.info("Flushing log up to LSN  %s", msg.data_start)
         msg.cursor.send_feedback(flush_lsn=msg.data_start)
 
     return state

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -58,6 +58,10 @@ class LogicalInterruption(unittest.TestCase):
                                     {"name" : 'colour', "type": "character varying"}],
                         "name" : 'COW'}
         ensure_test_table(table_spec_1)
+        global COW_RECORD_COUNT
+        COW_RECORD_COUNT = 0
+        global CAUGHT_MESSAGES
+        CAUGHT_MESSAGES.clear()
 
     def test_catalog(self):
         singer.write_message = singer_write_message_no_cow
@@ -160,6 +164,11 @@ class FullTableInterruption(unittest.TestCase):
                                     {"name" : 'colour', "type": "character varying"}],
                         "name" : 'CHICKEN'}
         ensure_test_table(table_spec_2)
+
+        global COW_RECORD_COUNT
+        COW_RECORD_COUNT = 0
+        global CAUGHT_MESSAGES
+        CAUGHT_MESSAGES.clear()
 
     def test_catalog(self):
         singer.write_message = singer_write_message_no_cow
@@ -273,10 +282,6 @@ class FullTableInterruption(unittest.TestCase):
         self.assertIsNone(singer.get_currently_syncing( CAUGHT_MESSAGES[5].value))
         self.assertIsNone(CAUGHT_MESSAGES[5].value['bookmarks']['postgres-public-CHICKEN']['xmin'])
         self.assertIsNone(singer.get_currently_syncing( CAUGHT_MESSAGES[5].value))
-
-
-
-
 
 
 if __name__== "__main__":

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -5,7 +5,11 @@ import tap_postgres.sync_strategies.full_table as full_table
 import pdb
 import singer
 from singer import get_logger, metadata, write_bookmark
-from tests.utils import get_test_connection, ensure_test_table, select_all_of_stream, set_replication_method_for_stream, insert_record, get_test_connection_config
+try:
+    from tests.utils import get_test_connection, ensure_test_table, select_all_of_stream, set_replication_method_for_stream, insert_record, get_test_connection_config
+except ImportError:
+    from utils import get_test_connection, ensure_test_table, select_all_of_stream, set_replication_method_for_stream, insert_record, get_test_connection_config
+
 import decimal
 import math
 import pytz
@@ -45,7 +49,104 @@ def do_not_dump_catalog(catalog):
 tap_postgres.dump_catalog = do_not_dump_catalog
 full_table.UPDATE_BOOKMARK_PERIOD = 1
 
-class CurrentlySyncing(unittest.TestCase):
+class LogicalInterruption(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        table_spec_1 = {"columns": [{"name": "id", "type" : "serial",       "primary_key" : True},
+                                    {"name" : 'name', "type": "character varying"},
+                                    {"name" : 'colour', "type": "character varying"}],
+                        "name" : 'COW'}
+        ensure_test_table(table_spec_1)
+
+    def test_catalog(self):
+        singer.write_message = singer_write_message_no_cow
+
+        conn_config = get_test_connection_config()
+        catalog = tap_postgres.do_discovery(conn_config)
+        cow_stream = [s for s in catalog.streams if s.table == 'COW'][0]
+        self.assertIsNotNone(cow_stream)
+        cow_stream = select_all_of_stream(cow_stream)
+        cow_stream = set_replication_method_for_stream(cow_stream, 'LOG_BASED')
+
+        with get_test_connection() as conn:
+            conn.autocommit = True
+            cur = conn.cursor()
+
+            cow_rec = {'name' : 'betty', 'colour' : 'blue'}
+            insert_record(cur, 'COW', cow_rec)
+            cow_rec = {'name' : 'smelly', 'colour' : 'brow'}
+            insert_record(cur, 'COW', cow_rec)
+
+        state = {}
+        #the initial phase of cows logical replication will be a full table.
+        #it will sync the first record and then blow up on the 2nd record
+        try:
+            tap_postgres.do_sync(get_test_connection_config(), catalog, None, state)
+        except Exception as ex:
+            # LOGGER.exception(ex)
+            blew_up_on_cow = True
+
+        self.assertTrue(blew_up_on_cow)
+        self.assertEqual(5, len(CAUGHT_MESSAGES))
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[0], singer.SchemaMessage))
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[1], singer.StateMessage))
+        self.assertIsNone(CAUGHT_MESSAGES[1].value['bookmarks']['postgres-public-COW'].get('xmin'))
+        self.assertIsNotNone(CAUGHT_MESSAGES[1].value['bookmarks']['postgres-public-COW'].get('lsn'))
+        end_lsn = CAUGHT_MESSAGES[1].value['bookmarks']['postgres-public-COW'].get('lsn')
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage))
+        new_version = CAUGHT_MESSAGES[2].version
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[3], singer.RecordMessage))
+        self.assertEqual(CAUGHT_MESSAGES[3].record, {'colour': 'blue', 'id': 1, 'name': 'betty'})
+        self.assertEqual('COW', CAUGHT_MESSAGES[3].stream)
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[4], singer.StateMessage))
+        #xmin is set while we are processing the full table replication
+        self.assertIsNotNone(CAUGHT_MESSAGES[4].value['bookmarks']['postgres-public-COW']['xmin'])
+        last_xmin = CAUGHT_MESSAGES[4].value['bookmarks']['postgres-public-COW']['xmin']
+
+        self.assertEqual(CAUGHT_MESSAGES[4].value['bookmarks']['postgres-public-COW']['lsn'], end_lsn)
+        old_state = CAUGHT_MESSAGES[4].value
+
+        #run another do_sync, should get the remaining record which effectively finishes the initial full_table
+        #replication portion of the logical replication
+        singer.write_message = singer_write_message_ok
+        global COW_RECORD_COUNT
+        COW_RECORD_COUNT = 0
+        CAUGHT_MESSAGES.clear()
+        tap_postgres.do_sync(get_test_connection_config(), catalog, None, old_state)
+
+        # pdb.set_trace()
+        self.assertEqual(6, len(CAUGHT_MESSAGES))
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[0], singer.SchemaMessage))
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[1], singer.StateMessage))
+        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['postgres-public-COW'].get('xmin'), last_xmin)
+        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['postgres-public-COW'].get('lsn'), end_lsn)
+        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['postgres-public-COW'].get('version'), new_version)
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[2], singer.RecordMessage))
+        self.assertEqual(CAUGHT_MESSAGES[2].record, {'colour': 'brow', 'id': 2, 'name': 'smelly'})
+        self.assertEqual('COW', CAUGHT_MESSAGES[2].stream)
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[3], singer.StateMessage))
+        self.assertTrue(CAUGHT_MESSAGES[3].value['bookmarks']['postgres-public-COW'].get('xmin') > last_xmin)
+        self.assertEqual(CAUGHT_MESSAGES[3].value['bookmarks']['postgres-public-COW'].get('lsn'), end_lsn)
+        self.assertEqual(CAUGHT_MESSAGES[3].value['bookmarks']['postgres-public-COW'].get('version'), new_version)
+
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[4], singer.ActivateVersionMessage))
+        self.assertEqual(CAUGHT_MESSAGES[4].version, new_version)
+
+        self.assertTrue(isinstance(CAUGHT_MESSAGES[5], singer.StateMessage))
+        self.assertIsNone(CAUGHT_MESSAGES[5].value['bookmarks']['postgres-public-COW'].get('xmin'))
+        self.assertEqual(CAUGHT_MESSAGES[5].value['bookmarks']['postgres-public-COW'].get('lsn'), end_lsn)
+        self.assertEqual(CAUGHT_MESSAGES[5].value['bookmarks']['postgres-public-COW'].get('version'), new_version)
+
+class FullTableInterruption(unittest.TestCase):
     maxDiff = None
     def setUp(self):
         table_spec_1 = {"columns": [{"name": "id", "type" : "serial",       "primary_key" : True},
@@ -90,7 +191,8 @@ class CurrentlySyncing(unittest.TestCase):
         #this will sync the CHICKEN but then blow up on the COW
         try:
             tap_postgres.do_sync(get_test_connection_config(), catalog, None, state)
-        except Exception:
+        except Exception as ex:
+            # LOGGER.exception(ex)
             blew_up_on_cow = True
 
         self.assertTrue(blew_up_on_cow)
@@ -178,6 +280,6 @@ class CurrentlySyncing(unittest.TestCase):
 
 
 if __name__== "__main__":
-    test1 = CurrentlySyncing()
+    test1 = LogicalInterruption()
     test1.setUp()
     test1.test_catalog()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ def get_test_connection(target_db='postgres'):
                                                                                    conn_config['user'],
                                                                                    conn_config['password'],
                                                                                    conn_config['port'])
-    LOGGER.info("connecting {}".format(conn_string))
+    LOGGER.info("connecting to {}".format(conn_config['host']))
 
     conn = psycopg2.connect(conn_string)
     conn.autocommit = True


### PR DESCRIPTION
xmin relied up for resuming full table replication that have been interrupted.  use the postgres age() to protect against transactionID wraparound