### PR TITLE
filter discovered DBs based on connectivity

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -331,11 +331,7 @@ def do_discovery(conn_config):
             cur.itersize = post_db.cursor_iter_size
             sql = """SELECT datname
             FROM pg_database
-            WHERE datistemplate = false
-                AND datname != 'cloudsqladmin'
-                AND CASE WHEN version() LIKE '%Redshift%' THEN true
-                        ELSE has_database_privilege(datname,'CONNECT')
-                    END = true """
+            WHERE datistemplate = false"""
 
             if conn_config.get('filter_dbs'):
                 sql = post_db.filter_dbs_sql_clause(sql, conn_config['filter_dbs'])

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,not-an-iterable,too-many-locals,too-many-arguments,invalid-name,too-many-return-statements,too-many-branches,len-as-condition,too-many-statements
+# pylint: disable=missing-docstring,not-an-iterable,too-many-locals,too-many-arguments,invalid-name,too-many-return-statements,too-many-branches,len-as-condition,too-many-statements,broad-except
 
 import datetime
 import pdb
@@ -340,7 +340,7 @@ def do_discovery(conn_config):
             cur.execute(sql)
             found_dbs = (row[0] for row in cur.fetchall())
 
-    filter_dbs = filter(lambda dbname: attempt_connection_to_db(conn_config, dbname) , found_dbs)
+    filter_dbs = filter(lambda dbname: attempt_connection_to_db(conn_config, dbname), found_dbs)
 
     for db_row in filter_dbs:
         dbname = db_row


### PR DESCRIPTION
has_database_privilege(stitch_user, 'CONNECT') is actually insufficient to ensure that we can connect to a given DB during discovery because of possible pg_hba.conf restrictions.  This will expressly run a connection check over every DB we can see to determine actually connectivity ability.