### PR TITLE
Feature/support view arrays

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -35,7 +35,7 @@ Column = collections.namedtuple('Column', [
     "character_maximum_length",
     "numeric_precision",
     "numeric_scale",
-    "array_dimensions",
+    "is_array",
     "is_enum"
 
 ])
@@ -171,7 +171,7 @@ def schema_for_column(c):
     #NB> from the post postgres docs: The current implementation does not enforce the declared number of dimensions either.
     #these means we can say nothing about an array column. its items may be more arrays or primitive types like integers
     #and this can vary on a row by row basis
-    if c.array_dimensions > 0:
+    if c.is_array:
         column_schema["type"] = ["null", "array"]
         column_schema["items"] = {}
         return Schema.from_dict(column_schema)
@@ -210,7 +210,7 @@ SELECT
                                                 THEN COALESCE(subpgt.typbasetype, pgt.typbasetype) ELSE COALESCE(subpgt.oid, pgt.oid)
                                         END,
                                        information_schema._pg_truetypmod(a.*, pgt.*))::information_schema.cardinal_number AS numeric_scale,
-  a.attndims                           AS array_dimensions,
+  pgt.typcategory                       = 'A' AS is_array,
   COALESCE(subpgt.typtype, pgt.typtype) = 'e' AS is_enum
 FROM pg_attribute a
 LEFT JOIN pg_type AS pgt ON a.atttypid = pgt.oid

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -553,7 +553,7 @@ class TestArraysLikeTable(unittest.TestCase):
                                  stream_dict.get('schema'))
 
 
- if __name__== "__main__":
-     test1 = TestArraysLikeTable()
-     test1.setUp()
-     test1.test_catalog()
+if __name__== "__main__":
+    test1 = TestArraysLikeTable()
+    test1.setUp()
+    test1.test_catalog()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,6 +5,7 @@ import tap_postgres
 import os
 import pdb
 from singer import get_logger, metadata
+from psycopg2.extensions import quote_ident
 try:
     from tests.utils import get_test_connection, ensure_test_table, get_test_connection_config
 except ImportError:
@@ -507,7 +508,52 @@ class TestMultiDB(unittest.TestCase):
                               ('properties', 'our_time_tz')        : {'inclusion': 'available', 'sql-datatype' : 'time with time zone', 'selected-by-default' : True}})
 
 
-if __name__== "__main__":
-    test1 = TestArraysTable()
-    test1.setUp()
-    test1.test_catalog()
+
+
+class TestArraysLikeTable(unittest.TestCase):
+    maxDiff = None
+    table_name = 'CHICKEN TIMES'
+    like_table_name = 'LIKE CHICKEN TIMES'
+
+    def setUp(self):
+        with get_test_connection('postgres') as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+                cur.execute('DROP MATERIALIZED VIEW IF EXISTS "LIKE CHICKEN TIMES"')
+        table_spec = {"columns": [{"name" : 'our_int_array_pk',          "type" : "integer[]", "primary_key" : True },
+                                  {"name" : 'our_text_array',            "type" : "text[]" }],
+                      "name" : TestArraysLikeTable.table_name}
+        ensure_test_table(table_spec)
+
+        with get_test_connection('postgres') as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+                 create_sql = "CREATE MATERIALIZED VIEW {} AS SELECT * FROM {}\n".format(quote_ident(TestArraysLikeTable.like_table_name, cur),
+                                                                                         quote_ident(TestArraysLikeTable.table_name, cur))
+
+
+                 cur.execute(create_sql)
+
+
+    def test_catalog(self):
+        conn_config = get_test_connection_config()
+        catalog = tap_postgres.do_discovery(conn_config)
+        chicken_streams = [s for s in catalog.streams if s.tap_stream_id == 'postgres-public-LIKE CHICKEN TIMES']
+        self.assertEqual(len(chicken_streams), 1)
+        stream_dict = chicken_streams[0].to_dict()
+        stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
+
+        with get_test_connection() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+                self.assertEqual(metadata.to_map(stream_dict.get('metadata')),
+                                 {() : {'table-key-properties': [], 'database-name': 'postgres', 'schema-name': 'public', 'is-view': True, 'row-count': 0},
+                                  ('properties', 'our_int_array_pk') : {'inclusion': 'available', 'sql-datatype' : 'integer[]',  'selected-by-default' : True},
+                                  ('properties', 'our_text_array') : {'inclusion': 'available', 'sql-datatype' : 'text[]',  'selected-by-default' : True}})
+                self.assertEqual({'properties': {'our_int_array_pk':                  {'type': ['null', 'array'], 'items' : {}},
+                                                 'our_text_array':                  {'type': ['null', 'array'], 'items' : {}}},
+                                  'type': 'object'},
+                                 stream_dict.get('schema'))
+
+
+# if __name__== "__main__":
+#     test1 = TestArraysLikeTable()
+#     test1.setUp()
+#     test1.test_catalog()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -553,7 +553,7 @@ class TestArraysLikeTable(unittest.TestCase):
                                  stream_dict.get('schema'))
 
 
-# if __name__== "__main__":
-#     test1 = TestArraysLikeTable()
-#     test1.setUp()
-#     test1.test_catalog()
+ if __name__== "__main__":
+     test1 = TestArraysLikeTable()
+     test1.setUp()
+     test1.test_catalog()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,7 @@ def ensure_test_table(table_spec, target_db='postgres'):
             old_table = cur.fetchall()
 
             if len(old_table) != 0:
-                cur.execute('DROP TABLE {}'.format(quote_ident(table_spec['name'], cur)))
+                cur.execute('DROP TABLE {} cascade'.format(quote_ident(table_spec['name'], cur)))
 
             sql = build_table(table_spec, cur)
             LOGGER.info("create table sql: %s", sql)


### PR DESCRIPTION
a.attndims is apparently a deprecated system column and should not be relied upon for determine if a column is in fact an array.  It, for instance, is not set correctly for views.  Use pg_type.typcategory instead.