### PR TITLE
Respect selected-by-default

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -434,17 +434,25 @@ def do_discovery(conn_config):
 
 
 def should_sync_column(md_map, field_name):
+
+    inclusion           = md_map.get(('properties', field_name), {}).get('inclusion')
+    selected            = md_map.get(('properties', field_name), {}).get('selected')
+    selected_by_default = md_map.get(('properties', field_name), {}).get('selected-by-default')
+
     #always sync replication_keys
     if md_map.get((), {}).get('replication-key') == field_name:
         return True
 
-    if md_map.get(('properties', field_name), {}).get('inclusion') == 'unsupported':
+    if inclusion == 'unsupported':
         return False
 
-    if md_map.get(('properties', field_name), {}).get('selected'):
+    if selected:
         return True
 
-    if md_map.get(('properties', field_name), {}).get('inclusion') == 'automatic':
+    if inclusion == 'automatic':
+        return True
+    
+    if selected_by_default and (selected != False):
         return True
 
     return False

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -435,8 +435,8 @@ def do_discovery(conn_config):
 
 def should_sync_column(md_map, field_name):
 
-    inclusion           = md_map.get(('properties', field_name), {}).get('inclusion')
-    selected            = md_map.get(('properties', field_name), {}).get('selected')
+    inclusion = md_map.get(('properties', field_name), {}).get('inclusion')
+    selected = md_map.get(('properties', field_name), {}).get('selected')
     selected_by_default = md_map.get(('properties', field_name), {}).get('selected-by-default')
 
     #always sync replication_keys
@@ -451,8 +451,8 @@ def should_sync_column(md_map, field_name):
 
     if inclusion == 'automatic':
         return True
-    
-    if selected_by_default and (selected != False):
+
+    if selected_by_default and (selected is not False):
         return True
 
     return False


### PR DESCRIPTION
This fixes an issue where tap-postgres currently doesn't treat selected-by-default the same way as tap-mysql or other taps. This change makes it so tap-postgres will sync a column if it is selected by default, as long as the user has not explicitly deselected it by setting `"selected": False`.

I tested it as follows.

* Ran the tap in discovery mode, saving the output to a file Confirmed that one of the tables ("batches") had many columns that were selected by default.
* I modified the discovered catalog to mark the "batches" table as selected, but did not select any other tables.
* Then I ran the tap again in sync mode, with the original code, and confirmed that only the id field was synced (because its inclusion is automatic).
* Then I made this change, ran the tap again, and confirmed that all the columns in the "batches" table were synced, but no other tables were synced.
* Then I marked some of the columns as not "selected-by-default", and marked others as explicitly "selected: False". Ran the tap again, and confirmed that those columns were _not_ included.