### PR TITLE
Primary Key Discovery with other indices

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -263,6 +263,7 @@ JOIN pg_catalog.pg_namespace n
 LEFT OUTER JOIN pg_index as i
   ON a.attrelid = i.indrelid
  AND a.attnum = ANY(i.indkey)
+ AND i.indisprimary = true
 LEFT OUTER JOIN pg_type AS subpgt
   ON pgt.typelem = subpgt.oid
  AND pgt.typelem != 0


### PR DESCRIPTION
Fixes an issue where primary keys could not be discovered, if there are other indices or unique constraints specified on the same column. This will only grab primary key indices for the purposes of discovery.