### PR TITLE
Remove unused requests package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'requests==2.12.4',
           'psycopg2==2.7.4',
           'strict-rfc3339==0.7',
           'nose==1.3.7'


### PR DESCRIPTION
The strict requirement for the requests package in tap-postgres means that you can't create a Pipfile with both tap-postgres and target-stitch [which has its own strict requirement for requests](https://github.com/singer-io/target-stitch/blob/8b417c077463e83174c9b6655e93b0f45229835b/setup.py#L15).

