### PR TITLE
Separate schema and stream name by '-'

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -13,7 +13,7 @@ include_schemas_in_destination_stream_name = False
 
 def calculate_destination_stream_name(stream, md_map):
     if include_schemas_in_destination_stream_name:
-        return "{}_{}".format(md_map.get((), {}).get('schema-name'), stream['stream'])
+        return "{}-{}".format(md_map.get((), {}).get('schema-name'), stream['stream'])
 
     return stream['stream']
 


### PR DESCRIPTION
Separating items by '-' character makes easier to identify schema and table names in target connector and it's in in-line with `compute_tap_stream_id` function. 