### PR TITLE
Add logging to show server and client encodings

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -34,14 +34,6 @@ def open_connection(conn_config, logical_replication=False):
     else:
         conn = psycopg2.connect(host=conn_config['host'], dbname=conn_config['dbname'], user=conn_config['user'], password=conn_config['password'], port=conn_config['port'], connect_timeout=30)
 
-    # Client side character encoding defaults to the value in postgresql.conf under client_encoding.
-    # The server / db can also have its own configred encoding.
-    with conn.cursor() as cur:
-        cur.execute("show server_encoding")
-        LOGGER.info("Current Server Encoding: %s", cur.fetchone()[0])
-        cur.execute("show client_encoding")
-        LOGGER.info("Current Client Encoding: %s", cur.fetchone()[0])
-
     return conn
 
 def prepare_columns_sql(c):

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -34,6 +34,14 @@ def open_connection(conn_config, logical_replication=False):
     else:
         conn = psycopg2.connect(host=conn_config['host'], dbname=conn_config['dbname'], user=conn_config['user'], password=conn_config['password'], port=conn_config['port'], connect_timeout=30)
 
+    # Client side character encoding defaults to the value in postgresql.conf under client_encoding.
+    # The server / db can also have its own configred encoding.
+    with conn.cursor() as cur:
+        cur.execute("show server_encoding")
+        LOGGER.info("Current Server Encoding: %s", cur.fetchone()[0])
+        cur.execute("show client_encoding")
+        LOGGER.info("Current Client Encoding: %s", cur.fetchone()[0])
+
     return conn
 
 def prepare_columns_sql(c):

--- a/tap_postgres/sync_strategies/full_table.py
+++ b/tap_postgres/sync_strategies/full_table.py
@@ -97,6 +97,15 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
     hstore_available = post_db.hstore_available(conn_info)
     with metrics.record_counter(None) as counter:
         with post_db.open_connection(conn_info) as conn:
+
+            # Client side character encoding defaults to the value in postgresql.conf under client_encoding.
+            # The server / db can also have its own configred encoding.
+            with conn.cursor() as cur:
+                cur.execute("show server_encoding")
+                LOGGER.info("Current Server Encoding: %s", cur.fetchone()[0])
+                cur.execute("show client_encoding")
+                LOGGER.info("Current Client Encoding: %s", cur.fetchone()[0])
+
             if hstore_available:
                 LOGGER.info("hstore is available")
                 psycopg2.extras.register_hstore(conn)

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -55,6 +55,15 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
     hstore_available = post_db.hstore_available(conn_info)
     with metrics.record_counter(None) as counter:
         with post_db.open_connection(conn_info) as conn:
+
+            # Client side character encoding defaults to the value in postgresql.conf under client_encoding.
+            # The server / db can also have its own configred encoding.
+            with conn.cursor() as cur:
+                cur.execute("show server_encoding")
+                LOGGER.info("Current Server Encoding: %s", cur.fetchone()[0])
+                cur.execute("show client_encoding")
+                LOGGER.info("Current Client Encoding: %s", cur.fetchone()[0])
+
             if hstore_available:
                 LOGGER.info("hstore is available")
                 psycopg2.extras.register_hstore(conn)


### PR DESCRIPTION
Its nice information to have when we open up a connection and run into errors with encoding.