### PR TITLE
make discovery work when user has SELECT on only some columns on a table

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -273,7 +273,7 @@ WHERE attnum > 0
 AND NOT a.attisdropped
 AND pg_class.relkind IN ('r', 'v', 'm')
 AND n.nspname NOT in ('pg_toast', 'pg_catalog', 'information_schema')
-AND has_table_privilege(pg_class.oid, 'SELECT') = true """)
+AND has_column_privilege(pg_class.oid, attname, 'SELECT') = true """)
         for row in cur.fetchall():
             row_count, is_view, schema_name, table_name, *col_info = row
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -576,6 +576,63 @@ class TestArraysLikeTable(unittest.TestCase):
                                   'definitions' : tap_postgres.BASE_RECURSIVE_SCHEMAS},
                                  stream_dict.get('schema'))
 
+class TestColumnGrants(unittest.TestCase):
+    maxDiff = None
+    table_name = 'CHICKEN TIMES'
+    user = 'tmp_user_for_grant_tests'
+    password = 'password'
+ 
+    def setUp(self):
+        table_spec = {"columns": [{"name" : "id",                "type" : "integer",  "serial" : True},
+                                 {"name" : 'size integer',      "type" : "integer",  "quoted" : True},
+                                 {"name" : 'size smallint',     "type" : "smallint", "quoted" : True},
+                                 {"name" : 'size bigint',       "type" : "bigint",   "quoted" : True}],
+                     "name" : TestColumnGrants.table_name}
+        ensure_test_table(table_spec)
+
+        with get_test_connection() as conn:
+           cur = conn.cursor()
+
+           sql = """ DROP USER IF EXISTS {} """.format(self.user, self.password)
+           LOGGER.info(sql)
+           cur.execute(sql)
+
+           sql = """ CREATE USER {} WITH PASSWORD '{}' """.format(self.user, self.password)
+           LOGGER.info(sql)
+           cur.execute(sql)
+
+           sql = """ GRANT SELECT ("id") ON "{}" TO {}""".format(TestColumnGrants.table_name, self.user)
+           LOGGER.info("running sql: {}".format(sql))
+           cur.execute(sql)
+
+           
+           
+
+    def test_catalog(self):
+        conn_config = get_test_connection_config()
+        conn_config['user'] = self.user
+        conn_config['password'] = self.password
+        streams = tap_postgres.do_discovery(conn_config)
+        chicken_streams = [s for s in streams if s['tap_stream_id'] == 'postgres-public-CHICKEN TIMES']
+
+        self.assertEqual(len(chicken_streams), 1)
+        stream_dict = chicken_streams[0]
+
+        self.assertEqual(TestStringTableWithPK.table_name, stream_dict.get('table_name'))
+        self.assertEqual(TestStringTableWithPK.table_name, stream_dict.get('stream'))
+
+
+        stream_dict.get('metadata').sort(key=lambda md: md['breadcrumb'])
+
+        self.assertEqual(metadata.to_map(stream_dict.get('metadata')),
+                         {() : {'table-key-properties': [], 'database-name': 'postgres', 'schema-name': 'public', 'is-view': False, 'row-count': 0},
+                          ('properties', 'id')                     : {'inclusion': 'available', 'sql-datatype' : 'integer', 'selected-by-default' : True}})
+        
+        self.assertEqual({'definitions' : tap_postgres.BASE_RECURSIVE_SCHEMAS,
+                          'type': 'object',
+                          'properties': {'id': {'type': ['null', 'integer'], 'minimum': -2147483648, 'maximum': 2147483647}}},
+                         stream_dict.get('schema'))
+
 
 if __name__== "__main__":
     test1 = TestArraysTable()


### PR DESCRIPTION
This change isn't compatible with Postgres<8.4, but we don't support versions prior to 9.3 anyway.

Tests confirm this change is backwards-compatible, as does this blurb from the postgres docs:

 > has_column_privilege checks whether a user can access a column in a particular way. Its argument possibilities are analogous to has_table_privilege, with the addition that the column can be specified either by name or attribute number. The desired access privilege type must evaluate to some combination of SELECT, INSERT, UPDATE, or REFERENCES. Note that having any of these privileges at the table level implicitly grants it for each column of the table.

