### PR TITLE
Add bigint[] to log-based type lookup

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -105,6 +105,8 @@ def create_array_elem(elem, sql_datatype, conn_info):
                 cast_datatype = 'text[]'
             elif sql_datatype == 'integer[]':
                 cast_datatype = 'integer[]'
+            elif sql_datatype == 'bigint[]':
+                cast_datatype = 'bigint[]'
             elif sql_datatype == 'inet[]':
                 cast_datatype = 'inet[]'
             elif sql_datatype == 'json[]':


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-895

For data types of `int8[]` that get reported by postgres as `bigint[]` into the metadata's `sql-datatype` field, log-based was incorrectly typing them as String during the data type conversion lookup. The schema still has integer for these columns, it's just that the records don't match once emitted.

This PR fixes that by adding a case for `bigint[]` and preventing the fallback to `text[]`.

# QA steps
 - [X] automated tests passing
   - Added this case to the integration test
 - [X] manual qa steps passing (list below)
   - Confirmed with a manual sync and breakpoint that adding this clause fixes the datatype for the intended column type

# Risks
Low, this is an additive change.

# Rollback steps
 - revert this branch
