### PR TITLE
Cast arrays and hstore columns using Python instead of Postgres db

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-postgres',
-      version='0.0.65',
+      version='0.0.66',
       description='Singer.io tap for extracting data from PostgreSQL',
       author='Stitch',
       url='https://singer.io',

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -1,0 +1,110 @@
+from decimal import Decimal
+import unittest
+from unittest.mock import patch
+
+from utils import get_test_connection_config
+from tap_postgres.sync_strategies import logical_replication
+
+
+class TestHandlingArrays(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(
+            'os.environ', {
+                'TAP_POSTGRES_HOST':'test',
+                'TAP_POSTGRES_USER':'test',
+                'TAP_POSTGRES_PASSWORD':'test',
+                'TAP_POSTGRES_PORT':'5432'
+            },
+        )
+
+        self.arrays = [
+            '{10,01,NULL}',
+            '{t,f,NULL}',
+            '{127.0.0.1/32,10.0.0.0/32,NULL}',
+            '{CASE_INSENSITIVE,case_insensitive,NULL,"CASE,,INSENSITIVE"}',
+            '{2000-12-31,2001-01-01,NULL}',
+            '{3.14159265359,3.1415926,NULL}',
+            '{"\\"foo\\"=>\\"bar\\"","\\"baz\\"=>NULL",NULL}',
+            '{1,2,NULL}',
+            '{9223372036854775807,NULL}',
+            '{198.24.10.0/24,NULL}',
+            '{"{\\"foo\\":\\"bar\\"}",NULL}',
+            '{"{\\"foo\\": \\"bar\\"}",NULL}',
+            '{08:00:2b:01:02:03,NULL}',
+            '{$19.99,NULL}',
+            '{19.9999999,NULL}',
+            '{3.14159,NULL}',
+            '{0,1,NULL}',
+            '{foo,bar,NULL,"foo,bar","diederik\'s motel "}',
+            '{16:38:47,NULL}',
+            '{"2019-11-19 11:38:47-05",NULL}',
+            '{123e4567-e89b-12d3-a456-426655440000,NULL}'
+        ]
+
+        self.sql_datatypes = {
+            'bit[]': bool,
+            'boolean[]': bool,
+            'cidr[]': str,
+            'citext[]': str,
+            'date[]': str,
+            'double precision[]': float,
+            'hstore[]': dict,
+            'integer[]': int,
+            'bigint[]': int,
+            'inet[]': str,
+            'json[]': str,
+            'jsonb[]': str,
+            'macaddr[]': str,
+            'money[]': Decimal,
+            'numeric[]': Decimal,
+            'real[]': float,
+            'smallint[]': int,
+            'text[]': str,
+            'time with time zone[]': str,
+            'timestamp with time zone[]': str,
+            'uuid[]': str,
+        }
+
+    def test_create_array_elem(self):
+        expected_arrays = [
+            ['10', '01' ,None],
+            ['t', 'f', None],
+            ['127.0.0.1/32', '10.0.0.0/32', None],
+            ['CASE_INSENSITIVE', 'case_insensitive', None,"CASE,,INSENSITIVE"],
+            ['2000-12-31', '2001-01-01', None],
+            ['3.14159265359','3.1415926', None],
+            ['"foo"=>"bar"', '"baz"=>NULL', None],
+            ['1','2',None],
+            ['9223372036854775807', None],
+            ['198.24.10.0/24', None],
+            ["{\"foo\":\"bar\"}", None],
+            ["{\"foo\": \"bar\"}", None],
+            ['08:00:2b:01:02:03', None],
+            ['$19.99', None],
+            ['19.9999999', None],
+            ['3.14159', None],
+            ['0','1', None],
+            ['foo','bar',None,"foo,bar","diederik\'s motel "],
+            ['16:38:47',None],
+            ["2019-11-19 11:38:47-05",None],
+            ['123e4567-e89b-12d3-a456-426655440000', None],
+        ]
+        for elem, expected_array in zip(self.arrays, expected_arrays):
+            array = logical_replication.create_array_elem(elem)
+            self.assertEqual(array, expected_array)
+
+    def test_selected_value_to_singer_value_impl(self):
+        with self.env:
+            conn_info = get_test_connection_config()
+            for elem, sql_datatype in zip(self.arrays, self.sql_datatypes.keys()):
+                array = logical_replication.selected_value_to_singer_value(elem, sql_datatype, conn_info)
+
+                for element in array:
+                    python_datatype = self.sql_datatypes[sql_datatype]
+                    if element:
+                        self.assertIsInstance(element, python_datatype)
+
+if __name__== "__main__":
+    test1 = TestHandlingArrays()
+    test1.setUp()
+    test1.test_selected_value_to_singer_value_impl()


### PR DESCRIPTION
# Description of change
Currently, the tap-postgres is using a live database connection to cast array and hstore columns to their Python equivalent when using logical replication as the synchronization strategy.


This live database connection is expensive and can create backlogs of large volumes of non-consumed data from the replication slot. This in turn can cause out-of-disk space errors which
then have to be prevented by dropping the replication slot and resetting the integration in Stitchdata and doing another full sync. 


This PR changes that behaviour and uses Python to do conversion of a Postgres stringified array into a Python list. 

I've also added unit tests to demonstrate that this approach works. The fixture data was generated by 
* creating a Postgres table using the SQL script below
* consume the events from the Postgres replication slot using the Python script at the bottom

```
CREATE EXTENSION IF NOT EXISTS citext;
DROP TABLE test;
CREATE TABLE IF NOT EXISTS test (
    id SERIAL,
    bit_array bit(2)[] NULL,
    boolean_array boolean[] NULL,
    cidr_array cidr[] NULL,
    citext_array citext[] NULL,
    date_array date[] NULL,
    double_precision_array double precision[] NULL,
    hstore_array hstore[] NULL,
    int_array integer[] NULL,
    bigint_array bigint[] NULL,
    inet_array inet[] NULL,
    json_array json[] NULL,
    jsonb_array jsonb[] NULL,
    macaddr_array macaddr[] NULL,
    money_array money[] NULL,
    decimal_array numeric[] NULL,
    real_array real[] NULL,
    smallint_array smallint[] NULL,
    text_array text[] NULL,
    time_array time without time zone[] NULL,
    timestamp_array timestamp with time zone[] NULL,
    uuid_array uuid[] NULL,
    PRIMARY KEY(id)
    );

BEGIN;
INSERT INTO test (bit_array,boolean_array,cidr_array,citext_array,date_array,double_precision_array,hstore_array,int_array,bigint_array,inet_array,json_array,jsonb_array,macaddr_array,money_array,decimal_array,real_array,smallint_array,text_array,time_array,timestamp_array,uuid_array)
    VALUES(
        '{"10", "01", null}',
        '{"true", "false", null}',
        '{"127.0.0.1", "10.0.0.0/32", null}',
        '{"CASE_INSENSITIVE", "case_insensitive", null, "CASE,,INSENSITIVE''"}',
        '{"12-31-2000", "01-01-2001", null}',
        '{"3.14159265359000", "3.1415926", null}',
        '{"foo => bar", "foo => null", null, "foo => bar,"}',
        '{"1", "2", null}',
        '{"9223372036854775807", null}',
        '{"198.24.10.0/24", null}',
        '{"{\"foo\":\"bar\"}", null}', -- json_array
        '{"{\"foo\":\"bar\"}", null}', -- jsonb_array
        '{"08:00:2b:01:02:03", null}',
        '{"19.99", null}', -- money_array,
        '{"19.9999999", null}', -- decimal_array,
        '{"3.14159", null}', -- real_array,
        '{"0", "1", null}', -- smallint_array,
        '{"foo", "bar", null, "foo,bar","diederik''s motel "}', -- text_array,
        '{"16:38:47+00:00", null}', -- time_array,
        '{"2019-11-19T16:38:47+00:00", null}', -- timestamp_array,
        '{"123e4567-e89b-12d3-a456-426655440000", null}' -- uuid_array
    );

COMMIT;
```


```
import time
import json
import psycopg2
from psycopg2.extras import LogicalReplicationConnection

conn = psycopg2.connect(
    'dbname=postgres user=postgres password=postgres host=127.0.0.1',
    connection_factory=psycopg2.extras.LogicalReplicationConnection
    )
cur = conn.cursor()
cur.start_replication(slot_name='test_slot', decode=True)
try:
    while True:
        try:
            message = cur.read_message()
        except psycopg2.DatabaseError as e:
            print("capture", e)
        if message:
            print(json.loads(message.payload))
            message.cursor.send_feedback(flush_lsn=message.data_start)
        else:            
            time.sleep(1.0)
except KeyboardInterrupt:
    cur.close()
    conn.close()
```

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks


# Rollback steps
 - revert this branch

@dmosorast @cmerrick @dylan-stitch