### PR TITLE
change full sync to order by xmin::text::bigint

### DIFF
--- a/tap_postgres/sync_strategies/full_table.py
+++ b/tap_postgres/sync_strategies/full_table.py
@@ -121,14 +121,14 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                     select_sql = """SELECT {}, xmin::text::bigint
                                       FROM {} where age(xmin::xid) <= age('{}'::xid)
                                      ORDER BY xmin::text::bigint ASC""".format(','.join(escaped_columns),
-                                                                       post_db.fully_qualified_table_name(schema_name, stream['table_name']),
-                                                                       xmin)
+                                                                               post_db.fully_qualified_table_name(schema_name, stream['table_name']),
+                                                                               xmin)
                 else:
                     LOGGER.info("Beginning new Full Table replication %s", nascent_stream_version)
                     select_sql = """SELECT {}, xmin::text::bigint
                                       FROM {}
                                      ORDER BY xmin::text::bigint ASC""".format(','.join(escaped_columns),
-                                                                       post_db.fully_qualified_table_name(schema_name, stream['table_name']))
+                                                                               post_db.fully_qualified_table_name(schema_name, stream['table_name']))
 
 
                 LOGGER.info("select %s with itersize %s", select_sql, cur.itersize)

--- a/tap_postgres/sync_strategies/full_table.py
+++ b/tap_postgres/sync_strategies/full_table.py
@@ -120,14 +120,14 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                     LOGGER.info("Resuming Full Table replication %s from xmin %s", nascent_stream_version, xmin)
                     select_sql = """SELECT {}, xmin::text::bigint
                                       FROM {} where age(xmin::xid) <= age('{}'::xid)
-                                     ORDER BY xmin::text ASC""".format(','.join(escaped_columns),
+                                     ORDER BY xmin::text::bigint ASC""".format(','.join(escaped_columns),
                                                                        post_db.fully_qualified_table_name(schema_name, stream['table_name']),
                                                                        xmin)
                 else:
                     LOGGER.info("Beginning new Full Table replication %s", nascent_stream_version)
                     select_sql = """SELECT {}, xmin::text::bigint
                                       FROM {}
-                                     ORDER BY xmin::text ASC""".format(','.join(escaped_columns),
+                                     ORDER BY xmin::text::bigint ASC""".format(','.join(escaped_columns),
                                                                        post_db.fully_qualified_table_name(schema_name, stream['table_name']))
 
 


### PR DESCRIPTION
# Description of change
The current logic performs a lexicographical `order by xmin::text`. In our specific case we had a table where `xmin` ranges from ~8700 to ~22000000, but because of the sorting logic the full sync would start at `xmin = 10000001` and any the full sync would miss roughly 1.2B rows.

Sorting by `xmin::text asc`:
![image](https://user-images.githubusercontent.com/25105438/69768203-acf34700-114d-11ea-8c31-b6c11cb17416.png)

Instead sorting by `xmin::text::bigint asc`:
![image](https://user-images.githubusercontent.com/25105438/69768226-c0061700-114d-11ea-86fd-d6fb50252dc9.png)

We were seeing about ~100M rows imported from the historical sync from table with ~1.3B rows. If we run the following query: `select count(*) from positions where xmin::text::bigint between 8703 and 10000000;`

we get the missing 1.2B row:
![image](https://user-images.githubusercontent.com/25105438/69768242-ce543300-114d-11ea-91fd-7f17454d2aba.png)


# QA steps
 - [x] automated tests passing
 
# Risks

# Rollback steps
 - revert this branch
