### PR TITLE
Enable SSL

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -28,11 +28,23 @@ def fully_qualified_table_name(schema, table):
     return '"{}"."{}"'.format(canonicalize_identifier(schema), canonicalize_identifier(table))
 
 def open_connection(conn_config, logical_replication=False):
+    cfg = {
+        'host': conn_config['host'],
+        'dbname': conn_config['dbname'],
+        'user': conn_config['user'],
+        'password': conn_config['password'],
+        'port': conn_config['port'],
+        'connect_timeout': 30
+    }
+
+    if conn_config.get('sslmode'):
+        cfg['sslmode'] = conn_config['sslmode']
+
     if logical_replication:
-        conn = psycopg2.connect(host=conn_config['host'], dbname=conn_config['dbname'], user=conn_config['user'], password=conn_config['password'], port=conn_config['port'],
-                                connection_factory=psycopg2.extras.LogicalReplicationConnection, connect_timeout=30)
-    else:
-        conn = psycopg2.connect(host=conn_config['host'], dbname=conn_config['dbname'], user=conn_config['user'], password=conn_config['password'], port=conn_config['port'], connect_timeout=30)
+        cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
+
+    conn = psycopg2.connect(**cfg)
+    LOGGER.info('Connection: %s', str(conn))
 
     return conn
 

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -44,7 +44,6 @@ def open_connection(conn_config, logical_replication=False):
         cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
 
     conn = psycopg2.connect(**cfg)
-    LOGGER.info('Connection: %s', str(conn))
 
     return conn
 


### PR DESCRIPTION
# Description of change
`ssl` is a config property for tap-postgres, but it wasn't actually being used when opening a connection to the db.  

This PR adds the `sslmode` param when opening a connection if the config prop `ssl` = `true`

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
  - Added `ssl: true` to tap-tester and verified that it passed locally
 
# Risks
connections that have ssl turned on but, for some reason, have it disabled on their db will start failing.

# Rollback steps
 - revert this branch
