### PR TITLE
bump version to 0.0.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.68
+  * Respect `ssl` config property (bug fix) [#80](https://github.com/singer-io/tap-postgres/pull/80)
+
 ## 0.0.67
   * Make `bytea[]` fields have `"inclusion" : "unsupported"` metadata [#76](https://github.com/singer-io/tap-postgres/pull/76)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-postgres',
-      version='0.0.67',
+      version='0.0.68',
       description='Singer.io tap for extracting data from PostgreSQL',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Bump version to 0.0.68

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
none

# Rollback steps
 - revert this branch
