### PR TITLE
add sslmode log message to tap-postgres

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -44,6 +44,7 @@ def open_connection(conn_config, logical_replication=False):
         cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
 
     conn = psycopg2.connect(**cfg)
+    LOGGER.info('Connected with sslmode = %s', conn.get_dsn_parameters().get('sslmode', 'unknown'))
 
     return conn
 


### PR DESCRIPTION
# Description of change
ssl for tap-postgres was recently enabled [here](#80).

This PR adds a log message to print the `sslmode`

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
  - Ran with `ssl='true'` and without any `ssl` config param and verified that the log message was correct
 
# Risks
none

# Rollback steps
 - revert this branch
