### PR TITLE
bump version to 0.0.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.69
+  * Add `sslmode` log message when opening connection [#82](https://github.com/singer-io/tap-postgres/pull/82)
+
 ## 0.0.68
   * Respect `ssl` config property (bug fix) [#80](https://github.com/singer-io/tap-postgres/pull/80)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-postgres',
-      version='0.0.68',
+      version='0.0.69',
       description='Singer.io tap for extracting data from PostgreSQL',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
bump version to 0.0.69

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
None

# Rollback steps
 - revert this branch
