### PR TITLE
Query db for ssl status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             pip install pylint
             source dev_env.sh
             make test
-            pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias, bare-except
+            pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias,bare-except
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             pip install pylint
             source dev_env.sh
             make test
-            pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias
+            pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias, bare-except
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -692,6 +692,8 @@ def main_impl():
 
     post_db.include_schemas_in_destination_stream_name = (args.config.get('include_schemas_in_destination_stream_name') == 'true')
 
+    post_db.get_ssl_status(conn_config)
+
     if args.discover:
         do_discovery(conn_config)
     elif args.properties:

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -23,7 +23,7 @@ def get_ssl_status(conn_config):
             LOGGER.info('User %s connected with SSL = %s', conn_config['user'], matching_rows[0][2])
         else:
             LOGGER.info('Failed to retrieve SSL status')
-    except:
+    except Exception as e:
         LOGGER.info('Failed to retrieve SSL status')
 
 

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -23,7 +23,7 @@ def get_ssl_status(conn_config):
             LOGGER.info('User %s connected with SSL = %s', conn_config['user'], matching_rows[0][2])
         else:
             LOGGER.info('Failed to retrieve SSL status')
-    except Exception as e:
+    except:
         LOGGER.info('Failed to retrieve SSL status')
 
 


### PR DESCRIPTION
# Description of change
A recent bug fix ensured that the `ssl` config parameters is actually used when connecting (#80).

This PR queries the [pg_stat_ssl](https://www.postgresql.org/docs/current/monitoring-stats.html#PG-STAT-SSL-VIEW) and [pg_stat_activity](https://www.postgresql.org/docs/current/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW) system views to grab the SSL status for the user connected to the db.  

This is wrapped in a generic try catch and will log a "Failed to retrieve SSL status" if:
1. No rows come back that match the user and dbname
2. More than 1 matching rows come back for the user and dbname
3. The postgres driver throws an exception

# QA steps
 - [ ] automated tests passing
 - [x] manual qa steps passing (list below)
  - Turned on/off SSL on a Postgres connection and verified the behavior
 
# Risks
None

# Rollback steps
 - revert this branch
