### PR TITLE
SSH Tunnel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,5 @@ ENV/
 env-vars.txt
 tap_oracle/__pycache__/
 *~
-config.json
+*config.json
+.vscode/

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.7.4',
+          'psycopg2==2.8.4',
           'strict-rfc3339==0.7',
           'nose==1.3.7'
       ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='tap-postgres',
           'singer-python==5.3.1',
           'psycopg2==2.8.4',
           'strict-rfc3339==0.7',
-          'nose==1.3.7'
+          'nose==1.3.7',
+          'sshtunnel==0.1.5'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -50,8 +50,8 @@ def open_connection(conn_config, logical_replication=False):
         'dbname': conn_config['dbname'],
         'user': conn_config['user'],
         'password': conn_config['password'],
-        'port': conn_config['port'],
-        'connect_timeout': 30
+        'port': int(conn_config['port']),
+        'connect_timeout': conn_config['connect_timeout'] if 'connect_timeout' in conn_config else 30
     }
 
     if conn_config.get('sslmode'):
@@ -61,7 +61,7 @@ def open_connection(conn_config, logical_replication=False):
         cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
 
     conn = psycopg2.connect(**cfg)
-
+    
     return conn
 
 def prepare_columns_sql(c):
@@ -69,7 +69,10 @@ def prepare_columns_sql(c):
     return column_name
 
 def filter_dbs_sql_clause(sql, filter_dbs):
-    in_clause = " AND datname in (" + ",".join(["'{}'".format(b.strip(' ')) for b in filter_dbs.split(',')]) + ")"
+    if isinstance(filter_dbs, str):
+        filter_dbs = ["{}".format(b.strip(' ')) for b in filter_dbs.split(',')] # split into a list 
+    filter_dbs = ["'{}'".format(b) for b in filter_dbs] # surround with single quotes
+    in_clause = " AND datname in (" + ",".join(filter_dbs) + ")"
     return sql + in_clause
 
 #pylint: disable=too-many-branches,too-many-nested-blocks


### PR DESCRIPTION
# Description of change
* Added support for SSH tunneling.
* Upgraded to latest version of psycopg2
* Added support for an array for the filter_dbs config property

# QA steps
 - [x ] automated tests passing
 - [x] manual qa steps passing (list below): tested by running discover

# Risks

# Rollback steps
 - revert this branch

# SSH Tunnel support
The connection is made of SSH Tunnel by adding the following to the config file:
```    
"use_ssh_tunnel": true,
"ssh_jump_server": "",
"ssh_jump_server_port": "",
"ssh_private_key_password": "", <-- this can be blank or left out if no passphrase on the pkey 
"ssh_private_key_path": "",
"ssh_username": ""
```

# Arrays for filter_db property
`filter_dbs` was a string: `"db1, db2, db3"`

Now it can alternatively be an array: ["db1", "db2", "db3"]