### PR TITLE
Support domain types

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -235,7 +235,6 @@ def produce_table_info(conn):
     with conn.cursor(cursor_factory=psycopg2.extras.DictCursor, name='stitch_cursor') as cur:
         cur.itersize = post_db.cursor_iter_size
         table_info = {}
-          # SELECT CASE WHEN $2.typtype = 'd' THEN $2.typbasetype ELSE $1.atttypid END
         cur.execute("""
 SELECT
   pg_class.reltuples::BIGINT                            AS approximate_row_count,
@@ -244,7 +243,7 @@ SELECT
   pg_class.relname                                      AS table_name,
   attname                                               AS column_name,
   i.indisprimary                                        AS primary_key,
-  format_type(a.atttypid, NULL::integer)                AS data_type,
+  format_type(CASE WHEN pgt.typtype = 'd' THEN pgt.typbasetype ELSE a.atttypid END, NULL::integer) AS data_type,
   information_schema._pg_char_max_length(CASE WHEN COALESCE(subpgt.typtype, pgt.typtype) = 'd'
                                               THEN COALESCE(subpgt.typbasetype, pgt.typbasetype) ELSE COALESCE(subpgt.oid, pgt.oid)
                                           END,

--- a/tests/test_postgres_full_table_replication.py
+++ b/tests/test_postgres_full_table_replication.py
@@ -61,6 +61,7 @@ expected_schemas = {'postgres_full_table_replication_test':
                                     'our_inet': {'type': ['null', 'string']},
                                     'our_mac': {'type': ['null', 'string']},
                                     'our_alignment_enum': {'type': ['null', 'string']},
+                                    'our_text_domain': {'type': ['null', 'string']},
                                     'our_money': {'type': ['null', 'string']}
                      }}}
 
@@ -123,6 +124,9 @@ class PostgresFullTable(unittest.TestCase):
                 cur.execute(""" DROP TYPE IF EXISTS ALIGNMENT CASCADE """)
                 cur.execute(""" CREATE TYPE ALIGNMENT AS ENUM ('good', 'bad', 'ugly') """)
 
+                cur.execute(""" DROP DOMAIN IF EXISTS text_domain_type CASCADE """)
+                cur.execute(""" CREATE DOMAIN text_domain_type text""")
+
                 create_table_sql = """
 CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                 our_varchar    VARCHAR,
@@ -150,6 +154,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                 our_cidr       cidr,
                 our_mac        macaddr,
                 our_alignment_enum ALIGNMENT,
+                our_text_domain    domain_type,
                 our_money          money)
                 """.format(canonicalized_table_name(test_schema_name, test_table_name, cur), NUMERIC_PRECISION, NUMERIC_SCALE)
 
@@ -188,6 +193,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                               'our_inet': '192.168.100.128/24',
                               'our_mac' : '08:00:2b:01:02:03',
                               'our_alignment_enum': 'good',
+                              'our_text_domain': 'hello, world!',
                               'our_money':    '100.1122',
                 }
 
@@ -338,6 +344,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
              ('properties', 'our_cidr'): {'inclusion': 'available', 'selected-by-default': True, 'sql-datatype': 'cidr'},
              ('properties', 'our_mac'): {'inclusion': 'available', 'selected-by-default': True, 'sql-datatype': 'macaddr'},
              ('properties', 'our_alignment_enum'): {'inclusion': 'available', 'selected-by-default': True, 'sql-datatype': 'alignment'},
+             ('properties', 'our_text_domain'): {'inclusion': 'available', 'selected-by-default': True, 'sql-datatype': 'text'},
              ('properties', 'our_money'): {'inclusion': 'available', 'selected-by-default': True, 'sql-datatype': 'money'}},
             metadata.to_map(md))
 
@@ -414,6 +421,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                              'our_cidr'    : self.rec_1['our_cidr'],
                              'our_mac'    : self.rec_1['our_mac'],
                              'our_alignment_enum' : self.rec_1['our_alignment_enum'],
+                             'our_text_domain' : self.rec_1['our_text_domain'],
                              'our_money'      : '$100.11'
         }
 

--- a/tests/test_postgres_logical_replication.py
+++ b/tests/test_postgres_logical_replication.py
@@ -59,6 +59,7 @@ expected_schemas = {'postgres_logical_replication_test':
                                     'our_inet': {'type': ['null', 'string']},
                                     'our_mac': {'type': ['null', 'string']},
                                     'our_alignment_enum': {'type': ['null', 'string']},
+                                    'our_text_domain': {'type': ['null', 'string']},
                                     'our_money': {'type': ['null', 'string']}}}}
 
 
@@ -139,6 +140,8 @@ class PostgresLogicalRep(unittest.TestCase):
                 cur.execute(""" DROP TYPE IF EXISTS ALIGNMENT CASCADE """)
                 cur.execute(""" CREATE TYPE ALIGNMENT AS ENUM ('good', 'bad', 'ugly') """)
 
+                cur.execute(""" DROP DOMAIN IF EXISTS text_domain_type CASCADE """)
+                cur.execute(""" CREATE DOMAIN text_domain_type text""")
 
                 create_table_sql = """
 CREATE TABLE {} (id            SERIAL PRIMARY KEY,
@@ -168,6 +171,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                 our_inet       inet,
                 our_mac            macaddr,
                 our_alignment_enum ALIGNMENT,
+                our_text_domain text_domain_type,
                 our_money          money)
                 """.format(canonicalized_table_name(test_schema_name, test_table_name, cur))
 
@@ -206,7 +210,8 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                               'our_cidr' : '192.168.100.128/25',
                               'our_inet': '192.168.100.128/24',
                               'our_mac' : '08:00:2b:01:02:03',
-                              'our_alignment_enum': 'bad'}
+                              'our_alignment_enum': 'bad',
+                              'our_text_domain': 'hello, world!'}
 
 
                 insert_record(cur, test_table_name, self.rec_1)
@@ -472,6 +477,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                                     'our_inet': '192.168.102.128',
                                     'our_mac': self.rec_3['our_mac'],
                                     'our_alignment_enum' : None,
+                                    'our_text_domain': None,
                                     'our_money'          :'$412.12'
         }
         self.assertEqual(set(actual_record_1.keys()), set(expected_inserted_record.keys()),
@@ -628,6 +634,7 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
                                 'our_inet': self.rec_1['our_inet'],
                                 'our_mac': self.rec_1['our_mac'],
                                 'our_alignment_enum' : 'bad',
+                                'our_text_domain': 'hello, world!',
                                 'our_money' : '$56.81'
         }
 


### PR DESCRIPTION

# Description of change
Type domain types as their underlying type.

Closes https://github.com/singer-io/tap-postgres/issues/97.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

Existing domain behaviour could be relied upon by current users, although unlikely as it's relatively u nfriendly. 

The new catalog would produce columns which are selected by default, rather than unsupported for domain types.

# Rollback steps
 - revert this branch
