### PR TITLE
Fix precision and scale truncation warnings

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -165,13 +165,14 @@ def compute_tap_stream_id(database_name, schema_name, table_name):
 
 #NB> numeric/decimal columns in postgres without a specified scale && precision
 #default to 'up to 131072 digits before the decimal point; up to 16383
-#digits after the decimal point'. For practical reasons, we are capping this at 74/38
+#digits after the decimal point'. For practical reasons, we are capping this at 100/38
 #  https://www.postgresql.org/docs/10/static/datatype-numeric.html#DATATYPE-NUMERIC-TABLE
 MAX_SCALE = 38
 MAX_PRECISION = 100
 
 def numeric_precision(c):
     if c.numeric_precision is None:
+        LOGGER.warning('capping decimal precision to 100.  THIS MAY CAUSE TRUNCATION')
         return MAX_PRECISION
 
     if c.numeric_precision > MAX_PRECISION:
@@ -182,7 +183,9 @@ def numeric_precision(c):
 
 def numeric_scale(c):
     if c.numeric_scale is None:
+        LOGGER.warning('capping decimal scale to 38.  THIS MAY CAUSE TRUNCATION')
         return MAX_SCALE
+
     if c.numeric_scale > MAX_SCALE:
         LOGGER.warning('capping decimal scale to 38.  THIS MAY CAUSE TRUNCATION')
         return MAX_SCALE


### PR DESCRIPTION
The current warning only occurs for columns with a set, but large,
value for precision and scale.

A column with no set precision and scale can store enormous
numbers, which would be truncated without triggering the
corresponding warning.

This change ensures a warning will be logged in both cases.

It also corrects the comment explaining the truncation.

# Risks
- very low
- finding bad data you thought was good

# Rollback steps
 - revert this branch
