### PR TITLE
added partitioned tables to discovery

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -274,7 +274,7 @@ LEFT OUTER JOIN pg_type AS subpgt
  AND pgt.typelem != 0
 WHERE attnum > 0
 AND NOT a.attisdropped
-AND pg_class.relkind IN ('r', 'v', 'm')
+AND pg_class.relkind IN ('r', 'v', 'm', 'p')
 AND n.nspname NOT in ('pg_toast', 'pg_catalog', 'information_schema')
 AND has_column_privilege(pg_class.oid, attname, 'SELECT') = true """)
         for row in cur.fetchall():


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/secure/RapidBoard.jspa?rapidView=23&modal=detail&selectedIssue=SUP-1796
This fix adds partitioned tables to the kinds of tables discovered.
The fix to include the 'p' is in this documentation under 'relkind field' description:
https://www.postgresql.org/docs/12/catalog-pg-class.html

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
- ran all tests (including unit tests), all passed
- ran on test client, everything came through, including the additional tables
 
# Risks

# Rollback steps
 - revert this branch
