### PR TITLE
Parse invalid dates

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -158,7 +158,10 @@ def selected_value_to_singer_value_impl(elem, og_sql_datatype, conn_info):
         if  isinstance(elem, datetime.date):
             #logical replication gives us dates as strings UNLESS they from an array
             return elem.isoformat() + 'T00:00:00+00:00'
-        return parse(elem).isoformat() + "+00:00"
+        try:
+            return parse(elem).isoformat() + "+00:00"
+        except ValueError:
+            return parse('9999-12-31T00:00:00+00:00').isoformat()
     if sql_datatype == 'time with time zone':
         return parse(elem).isoformat().split('T')[1]
     if sql_datatype == 'bit':


### PR DESCRIPTION
# Description of change
Resolves #94
Another solution: https://github.com/singer-io/tap-postgres/pull/95

Python can only parse dates up to `9999-12-31`. When we try to work with a date past the maximum supported, a ValueError is being thrown.

These dates are invalid anyway, so I decided to just hardcode them to the maximum supported date.

# QA steps
 - [X] automated tests passing
 - [X] manual qa steps passing (list below)

I actually couldn't make the logical replication slot working. Other than that, all unit tests pass.

Manual test:
1. Create a Postgres table
``` sql
create table test_table (id serial primary key, created_date date);
```
2. Insert some rows:
```sql
insert into test_table(created_date) values('1989-02-27'), ('9999-12-31'), ('10000-01-01');
```
3. Ran the tap and confirmed it fails
4. Added a Snowflake target
5. Ran the tap against the target and confirmed it fails again
6. Made the change
7. Ran the tap confirmed it pass
8. Ran the tap against the target and confirmed it pass again
9. Ran the `INSERT` query again
10. Ran the tap against the target and confirmed it pass again

Result value in Snowflake - `9999-12-31 00:00:00.000`
 
# Risks
We'd obviously have some data loss when we have dates 8000 years from now.

# Rollback steps
 - revert this branch