### PR TITLE
Filter logical replication tables

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -684,7 +684,8 @@ def main_impl():
                    'filter_dbs' : args.config.get('filter_dbs'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
-                   'wal2json_message_format': args.config.get('wal2json_message_format')}
+                   'wal2json_message_format': args.config.get('wal2json_message_format'),
+                   'wal2json_slot_name': args.config.get('wal2json_slot_name')}
 
     if args.config.get('ssl') == 'true':
         conn_config['sslmode'] = 'require'

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -379,6 +379,11 @@ def consume_message(streams, state, msg, time_extracted, conn_info, end_lsn, mes
     return state
 
 def locate_replication_slot(conn_info):
+    if conn_info.get('wal2json_slot_name') is not None:
+        slot_name = conn_info["wal2json_slot_name"]
+        LOGGER.info("using pg_replication_slot %s", slot_name)
+        return slot_name
+
     with post_db.open_connection(conn_info, False) as conn:
         with conn.cursor() as cur:
             db_specific_slot = "stitch_{}".format(conn_info['dbname'])


### PR DESCRIPTION
# Description of change
wal2json has an option where we can set which tables should be synced. We have to list tables we want to sync either way so there's no reason not to use that list. This change lowers the load on the network traffic and prevents potential leaks.

# QA steps
 - [X] automated tests passing
 - [X] manual qa steps passing (list below)
 
# Risks
Can't really think of any

# Rollback steps
 - revert this branch
