### PR TITLE
Use flexidate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='tap-postgres',
           'singer-python==5.3.1',
           'psycopg2==2.7.4',
           'strict-rfc3339==0.7',
+          'flexidate==1.4',
       ],
       extras_require={
           'dev': [

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -8,7 +8,7 @@ from singer import utils, get_bookmark
 import singer.metadata as metadata
 import tap_postgres.db as post_db
 import tap_postgres.sync_strategies.common as sync_common
-from dateutil.parser import parse
+from flexidate import parse
 import psycopg2
 from psycopg2 import sql
 import copy

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -157,8 +157,8 @@ def selected_value_to_singer_value_impl(elem, og_sql_datatype, conn_info):
     if sql_datatype == 'date':
         if  isinstance(elem, datetime.date):
             #logical replication gives us dates as strings UNLESS they from an array
-            return elem.isoformat() + 'T00:00:00+00:00'
-        return parse(elem).isoformat() + "+00:00"
+            return elem.isoformat()
+        return parse(elem).isoformat()
     if sql_datatype == 'time with time zone':
         return parse(elem).isoformat().split('T')[1]
     if sql_datatype == 'bit':


### PR DESCRIPTION
# Description of change
Fix #94 
Flexidate is a date parser that works well with dates not supported by Python's built-in datetime package.

# QA steps
 - [X] automated tests passing
 - [X] manual qa steps passing (list below)

1. Insert 3 records with 3 different date values - todays date, a BC date and a date in year 10000.
2. Start the initial sync
3. Insert 3 new records with similiar dates
4. Start incremental sync
5. Check the values in the target

# Risks
The target needs to handle these dates properly otherwise, there will be a similar error.

# Rollback steps
 - revert this branch
