### PR TITLE
Fixes to allow python3.8 tap-tester default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,11 @@ jobs:
             source dev_env.sh
             make test
             pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias,bare-except,raise-missing-from
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json ~/.virtualenvs/tap-postgres/lib/python3.8/site-packages/tap_postgres/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
-            apt-get install -y libpq-dev python-dev
+            pyenv local 3.5.2
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U pip setuptools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
-            apt-get install libpq-dev python-dev
+            apt-get install -y libpq-dev python-dev
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U pip setuptools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,11 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
+            sudo apt-get install libpq-dev python-dev
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
-            pip install .
-            pip install pylint
+            pip install -U pip setuptools
+            pip install .[dev]
             source dev_env.sh
             make test
             pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias,bare-except,raise-missing-from

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json ~/.virtualenvs/tap-postgres/lib/python3.8/site-packages/tap_postgres/schemas/*.json
+            stitch-validate-json tap_postgres/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,6 @@ jobs:
             source dev_env.sh
             make test
             pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias,bare-except,raise-missing-from
-      - run:
-          name: 'JSON Validator'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json tap_postgres/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
-            sudo apt-get install libpq-dev python-dev
+            apt-get install libpq-dev python-dev
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U pip setuptools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             pyenv local 3.5.2
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
-            pip install -U pip setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
             source dev_env.sh
             make test

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,14 @@ setup(name='tap-postgres',
           'singer-python==5.3.1',
           'psycopg2==2.7.4',
           'strict-rfc3339==0.7',
-          'nose==1.3.7'
       ],
+      extras_require={
+          'dev': [
+              'ipdb',
+              'pylint',
+              'nose==1.3.7',
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-postgres=tap_postgres:main


### PR DESCRIPTION
# Description of change
Fixes to allow python3.8 tap-tester default

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
