### PR TITLE
make a separate test db for the log rep test,

### DIFF
--- a/bin/test-db
+++ b/bin/test-db
@@ -10,11 +10,11 @@ full_image_name = "singerio/postgres:9.6-wal2json-2.2-ssl"
 
 def start_container(name):
     START_COMMAND = """
-    sudo docker run -e "POSTGRES_USER={0}" -e "POSTGRES_PASSWORD={1}" -p {2}:{2} --name {3} -d {4} \
+    sudo docker run -e "POSTGRES_USER={0}" -e "POSTGRES_PASSWORD={1}" -p {2}:5432 --name {3} -d {4} \
                     postgres -c config_file=/usr/local/share/postgresql/postgresql.conf
     """.format(os.getenv('TAP_POSTGRES_USER'),
                os.getenv('TAP_POSTGRES_PASSWORD'),
-               5432,
+               os.getenv('TAP_POSTGRES_PORT'),
                name,
                full_image_name)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.8.4',
+          'psycopg2==2.7.4',
           'strict-rfc3339==0.7',
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.7.4',
+          'psycopg2==2.8.4',
           'strict-rfc3339==0.7',
       ],
       extras_require={

--- a/tests/db_utils.py
+++ b/tests/db_utils.py
@@ -13,7 +13,7 @@ def ensure_environment_variables_set():
 
 def ensure_db(dbname=os.getenv('TAP_POSTGRES_DBNAME')):
     # Create database dev if not exists
-    with get_test_connection() as conn:
+    with get_test_connection('postgres') as conn:
         conn.autocommit = True
         with conn.cursor() as cur:
             cur.execute("SELECT 1 FROM pg_database WHERE datname = '{}'".format(dbname))
@@ -23,11 +23,13 @@ def ensure_db(dbname=os.getenv('TAP_POSTGRES_DBNAME')):
                 cur.execute("CREATE DATABASE {}".format(dbname))
 
 def get_test_connection(dbname=os.getenv('TAP_POSTGRES_DBNAME'), logical_replication=False):
+
     conn_string = "host='{}' dbname='{}' user='{}' password='{}' port='{}'".format(os.getenv('TAP_POSTGRES_HOST'),
                                                                                    dbname,
                                                                                    os.getenv('TAP_POSTGRES_USER'),
                                                                                    os.getenv('TAP_POSTGRES_PASSWORD'),
                                                                                    os.getenv('TAP_POSTGRES_PORT'))
+
     if logical_replication:
         return psycopg2.connect(conn_string, connection_factory=psycopg2.extras.LogicalReplicationConnection)
     else:

--- a/tests/test_postgres_logical_replication.py
+++ b/tests/test_postgres_logical_replication.py
@@ -812,7 +812,6 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
 
         #third record will be the new update
         updated_message = records_by_stream['postgres_logical_replication_test']['messages'][2]
-        updated_sdc_lsn = int(updated_message['data']['_sdc_lsn'])
         del updated_message['data']['_sdc_lsn']
 
         self.assertEqual(updated_message['action'], 'upsert')

--- a/tests/test_postgres_logical_replication.py
+++ b/tests/test_postgres_logical_replication.py
@@ -613,7 +613,6 @@ CREATE TABLE {} (id            SERIAL PRIMARY KEY,
         if expected_record_count == 2:
             # the 1st message will be the previous insert
             insert_message = records_by_stream['postgres_logical_replication_test']['messages'][0]['data']
-            inserted_sdc_lsn = int(insert_message['_sdc_lsn'])
             del insert_message['_sdc_lsn']
 
             self.assertDictEqual(insert_message, expected_inserted_record)


### PR DESCRIPTION
# Description of change
Attempt to stabilize logical replication test by using a separate test database than the other tests.
Update bin/test-db to use port env var.
Update db_utils to work on a fresh test-db, by connecting to the `postgres` db prior to checking if the test_db is available.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
