### PR TITLE
removed the pylint tests step from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,6 @@ jobs:
             pylint tap_postgres -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,duplicate-code,useless-import-alias,bare-except,raise-missing-from
       - add_ssh_keys
       - run:
-          name: 'pylint tests'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            pip install pylint
-            pylint tests/*.py -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring'
-      - run:
           when: always
           name: 'Integration Tests'
           command: |


### PR DESCRIPTION
# Description of change
Remove the pylint for the tests. This should not be a part of the standard build.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
