### PR TITLE
Bump python 396

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:ubuntu-1804-stitch-tap-tester
       - image: singerio/postgres:9.6-wal2json-2.2-ssl
         environment:
           POSTGRES_USER: postgres
@@ -19,7 +19,6 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
-            pyenv local 3.9.6
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            # pip install psycopg2==2.8.4
+            pip install psycopg2==2.8.6
             run-test --tap=tap-postgres tests
       - slack/notify-on-failure:
           only_for_branches: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:ubuntu-1804-stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
       - image: singerio/postgres:9.6-wal2json-2.2-ssl
         environment:
           POSTGRES_USER: postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
-            pyenv local 3.5.2
+            pyenv local 3.9.6
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
@@ -35,7 +35,7 @@ jobs:
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             apt install -y libpq-dev
-            pip install psycopg2==2.8.4
+            # pip install psycopg2==2.8.4
             run-test --tap=tap-postgres tests
       - slack/notify-on-failure:
           only_for_branches: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
+            apt install -y libpq-dev
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
@@ -33,7 +34,6 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            apt install -y libpq-dev
             # pip install psycopg2==2.8.4
             run-test --tap=tap-postgres tests
       - slack/notify-on-failure:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.7.4',
+          'psycopg2==2.9.1',
           'strict-rfc3339==0.7',
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.9.1',
+          'psycopg2==2.8.6',
           'strict-rfc3339==0.7',
       ],
       extras_require={


### PR DESCRIPTION
# Description of change
Changes to support Python 3.9.6, the only issues encountered were in relation to psycopg2 not being available at version 2.7.4 for the latest versions of everything else, so we are bumping it a minor version and change to 2.8.6.

# QA steps
 - [X] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
Issues with scenarios that are not under test could crop up, but we have confidence in the current amount of tests.

# Rollback steps
 - revert this branch
