### PR TITLE
Revert "Bump python 396 (#130)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             export LC_ALL=C
-            apt install -y libpq-dev
+            pyenv local 3.5.2
             python3 -m venv /usr/local/share/virtualenvs/tap-postgres
             source /usr/local/share/virtualenvs/tap-postgres/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
@@ -34,7 +34,8 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            pip install psycopg2==2.8.6
+            apt install -y libpq-dev
+            pip install psycopg2==2.8.4
             run-test --tap=tap-postgres tests
       - slack/notify-on-failure:
           only_for_branches: master

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.8.6',
+          'psycopg2==2.7.4',
           'strict-rfc3339==0.7',
       ],
       extras_require={


### PR DESCRIPTION
This reverts #130 

# Description of change
#130 was merged with the intention that we would be bumping to 3.9.6. However, we've found a potential bug introduced in python 3.6.0. We're opting to revert this for now.

# QA steps
 - [X] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
None, this reverts to a working commit

# Rollback steps
 - revert this branch
