### PR TITLE
Use psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-postgres',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.7.4',
+          'psycopg2-binary==2.7.4',
           'strict-rfc3339==0.7',
       ],
       extras_require={


### PR DESCRIPTION
Meltano users cannot use this variant of tap-postgres, because it cannot build when installing

# Description of change
(write a short description here or paste a link to JIRA)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
