### PR TITLE
remove singer imports

### DIFF
--- a/tests/db_utils.py
+++ b/tests/db_utils.py
@@ -2,6 +2,10 @@ import os
 import psycopg2
 from psycopg2.extensions import quote_ident
 
+# steal top_map method from singer-python so we can remove singer imports from tests
+def to_map(raw_metadata):
+    return {tuple(md['breadcrumb']): md['metadata'] for md in raw_metadata}
+
 def ensure_environment_variables_set():
     missing_envs = [x for x in [os.getenv('TAP_POSTGRES_HOST'),
                                 os.getenv('TAP_POSTGRES_USER'),

--- a/tests/test_postgres_views_full_table.py
+++ b/tests/test_postgres_views_full_table.py
@@ -3,7 +3,6 @@ import unittest
 
 import psycopg2.extras
 from psycopg2.extensions import quote_ident
-from singer import metadata
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
@@ -184,7 +183,7 @@ class PostgresViewsFullTable(unittest.TestCase):
              ('properties', 'age'): {'inclusion': 'available', 'sql-datatype': 'integer', 'selected-by-default': True},
              ('properties', 'size'): {'inclusion': 'available', 'sql-datatype': 'character varying', 'selected-by-default': True},
              ('properties', 'id'): {'inclusion': 'available', 'sql-datatype': 'integer', 'selected-by-default': True}},
-            metadata.to_map(md))
+            db_utils.to_map(md))
 
 
         # 'ID' selected as view-key-properties

--- a/tests/test_postgres_views_incremental_replication.py
+++ b/tests/test_postgres_views_incremental_replication.py
@@ -4,7 +4,6 @@ import unittest
 
 import psycopg2.extras
 from psycopg2.extensions import quote_ident
-from singer import metadata
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
@@ -190,7 +189,7 @@ class PostgresViewsIncrementalReplication(unittest.TestCase):
              ('properties', 'size'): {'inclusion': 'available', 'sql-datatype': 'character varying', 'selected-by-default': True},
              ('properties', 'id'): {'inclusion': 'available', 'sql-datatype': 'integer', 'selected-by-default': True},
              ('properties', 'updated_at'): {'selected-by-default': True, 'inclusion': 'available', 'sql-datatype': 'timestamp with time zone'}},
-            metadata.to_map(md))
+            db_utils.to_map(md))
 
 
         # 'ID' selected as view-key-properties, updated_at is replication_key

--- a/tests/test_postgres_views_logical_replication.py
+++ b/tests/test_postgres_views_logical_replication.py
@@ -3,7 +3,6 @@ import unittest
 
 import psycopg2.extras
 from psycopg2.extensions import quote_ident
-from singer import metadata
 import tap_tester.connections as connections
 import tap_tester.menagerie   as menagerie
 import tap_tester.runner      as runner
@@ -176,7 +175,7 @@ class PostgresViewsLogicalReplication(unittest.TestCase):
              ('properties', 'age'): {'inclusion': 'available', 'sql-datatype': 'integer', 'selected-by-default': True},
              ('properties', 'size'): {'inclusion': 'available', 'sql-datatype': 'character varying', 'selected-by-default': True},
              ('properties', 'id'): {'inclusion': 'available', 'sql-datatype': 'integer', 'selected-by-default': True}},
-            metadata.to_map(md))
+            db_utils.to_map(md))
 
 
         # 'ID' selected as view-key-properties


### PR DESCRIPTION
# Description of change
remove singer imports to avoid double logging

# QA steps
 - [x] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks
low
# Rollback steps
 - revert this branch
