### PR TITLE
Stabilize discovery test using standard top level breadcrumb filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
       - build:
           context:
             - circleci-user
-            - tier-1-tap-user
+            - tap-tester-user
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-18.04
       - image: singerio/postgres:9.6-wal2json-2.2-ssl
         environment:
           POSTGRES_USER: postgres

--- a/tests/test_postgres_discovery.py
+++ b/tests/test_postgres_discovery.py
@@ -404,7 +404,7 @@ CREATE TABLE {} (id                   SERIAL PRIMARY KEY,
                 )
                 actual_fields_to_datatypes = {
                     item['breadcrumb'][1]: item['metadata'].get('sql-datatype')
-                    for item in stream_metadata[1:]
+                    for item in stream_metadata if item['breadcrumb'] != []
                 }
 
                 # Verify there is only 1 top level breadcrumb in metadata


### PR DESCRIPTION
# Description of change
Stabilize discovery test using standard top level breadcrumb filter

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
